### PR TITLE
Fixes typo

### DIFF
--- a/code/chapter_01_example_09.py
+++ b/code/chapter_01_example_09.py
@@ -39,4 +39,6 @@ patterns = [
     path(route='add/',
         view=views.add_topping,
         name='add_topping'),
-    ]
+    ],
+]
+


### PR DESCRIPTION
I am using trailing comma, since these lines:

```python
view=views.add_topping,
name='add_topping'),
```

also use trailing commas.